### PR TITLE
Add Micro Program crawler & JSON output for frontend consumption

### DIFF
--- a/.github/workflows/fetchCurrentMPrograms.yaml
+++ b/.github/workflows/fetchCurrentMPrograms.yaml
@@ -1,0 +1,28 @@
+name: fetch current mprograms
+
+on:
+  push:
+    branches:
+      - 蹦蹦
+  schedule:
+    - cron: "0 0 */1 * *"
+
+jobs:
+  FetchMProgram:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Install npm packages
+        run: npm install
+      - name: Fetch micro program data
+        run: node fetchMProgram.js
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          keep_files: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ https://ntut-course.gnehs.net/api
 - clone repo
 - `cd ./path/ntut-course-crawler-node`
 - `npm i`
-- `node fetchAll.js` or `node fetchCourse.js`
+- `node fetchAll.js`
+- `node fetchCourse.js`
+- `node fetchMProgram.js`
 
 ## 提醒
 - 課程網站若抓取過快很容易被封鎖，因此本爬蟲有限制同一時間抓取頁面數量，可自行調整。

--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -14,9 +14,10 @@ async function fetchProgramCourse(href, page) {
     const url = "https://aps.ntut.edu.tw/course/tw/" + href;
     $ = await fetchSinglePage(url);
   }
-  $("tr:first-child").remove();
+  const table = $("table").first();
+  const rows = table.find("tr").slice(1);
   const courses = [];
-  for (const tr of $("tr")) {
+  for (const tr of rows) {
     const id = $(tr)
       .children("td")
       .first()

--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -1,3 +1,4 @@
+const cheerio = require("cheerio");
 const { fetchSinglePage } = require("./fetchSinglePage");
 const jsonfile = require("jsonfile");
 const fs = require("fs");
@@ -5,39 +6,48 @@ const pangu = require("./tools/pangu").spacing;
 
 const globalRegexParse = /\n|^ | $/g;
 
-async function fetchProgramCourse(href) {
-  const url = "https://aps.ntut.edu.tw/course/tw/" + href;
-  const $ = await fetchSinglePage(url);
+async function fetchProgramCourse(href, page) {
+  let $;
+  if (page) {
+    $ = typeof page === "string" ? cheerio.load(page) : page;
+  } else {
+    const url = "https://aps.ntut.edu.tw/course/tw/" + href;
+    $ = await fetchSinglePage(url);
+  }
   $("tr:first-child").remove();
-  $("tr:last-child").remove();
   const courses = [];
   for (const tr of $("tr")) {
-    const id = $($(tr).children("td")[0]).text().replace(globalRegexParse, "");
-    const nameLink = $($(tr).children("td")[1]).find("a");
-    if (!id || !nameLink.length) continue;
-    courses.push({
-      id,
-      name: pangu(nameLink.text().replace(globalRegexParse, "")),
-      href: nameLink.attr("href"),
-    });
+    const id = $(tr)
+      .children("td")
+      .first()
+      .text()
+      .replace(globalRegexParse, "");
+    if (id) courses.push(id);
   }
   return courses;
 }
 
-async function fetchMProgram(year = 110, sem = 2) {
+async function fetchMProgram(year = 110, sem = 2, listPage = null, programPages = {}) {
   console.log("[fetch] 正在取得微學程列表...");
-  const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
-  const $ = await fetchSinglePage(url);
+  let $;
+  if (listPage) {
+    $ = typeof listPage === "string" ? cheerio.load(listPage) : listPage;
+  } else {
+    const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
+    $ = await fetchSinglePage(url);
+  }
   const programs = $("a[href^='SearchMProgram.jsp?format=-2']");
   const res = [];
   let progress = 0;
   for (const program of programs) {
     const name = pangu($(program).text());
     const href = $(program).attr("href");
+    const urlParser = new URL("https://aps.ntut.edu.tw/course/tw/" + href);
+    const id = urlParser.searchParams.get("code");
     progress++;
     console.log(`[fetch] 正在取得 (${progress}/${programs.length}) ${name}`);
-    const course = await fetchProgramCourse(href);
-    res.push({ name, href, course });
+    const course = await fetchProgramCourse(href, programPages[id]);
+    res.push({ id, name, href, course });
   }
   fs.mkdirSync(`./dist/${year}/${sem}/`, { recursive: true });
   jsonfile.writeFileSync(`./dist/${year}/${sem}/mprogram.json`, res, {

--- a/crawler/fetchMProgram.js
+++ b/crawler/fetchMProgram.js
@@ -1,0 +1,49 @@
+const { fetchSinglePage } = require("./fetchSinglePage");
+const jsonfile = require("jsonfile");
+const fs = require("fs");
+const pangu = require("./tools/pangu").spacing;
+
+const globalRegexParse = /\n|^ | $/g;
+
+async function fetchProgramCourse(href) {
+  const url = "https://aps.ntut.edu.tw/course/tw/" + href;
+  const $ = await fetchSinglePage(url);
+  $("tr:first-child").remove();
+  $("tr:last-child").remove();
+  const courses = [];
+  for (const tr of $("tr")) {
+    const id = $($(tr).children("td")[0]).text().replace(globalRegexParse, "");
+    const nameLink = $($(tr).children("td")[1]).find("a");
+    if (!id || !nameLink.length) continue;
+    courses.push({
+      id,
+      name: pangu(nameLink.text().replace(globalRegexParse, "")),
+      href: nameLink.attr("href"),
+    });
+  }
+  return courses;
+}
+
+async function fetchMProgram(year = 110, sem = 2) {
+  console.log("[fetch] 正在取得微學程列表...");
+  const url = `https://aps.ntut.edu.tw/course/tw/SearchMProgram.jsp?format=-1&year=${year}&sem=${sem}`;
+  const $ = await fetchSinglePage(url);
+  const programs = $("a[href^='SearchMProgram.jsp?format=-2']");
+  const res = [];
+  let progress = 0;
+  for (const program of programs) {
+    const name = pangu($(program).text());
+    const href = $(program).attr("href");
+    progress++;
+    console.log(`[fetch] 正在取得 (${progress}/${programs.length}) ${name}`);
+    const course = await fetchProgramCourse(href);
+    res.push({ name, href, course });
+  }
+  fs.mkdirSync(`./dist/${year}/${sem}/`, { recursive: true });
+  jsonfile.writeFileSync(`./dist/${year}/${sem}/mprogram.json`, res, {
+    spaces: 2,
+    EOL: "\r\n",
+  });
+}
+
+module.exports = { fetchMProgram };

--- a/fetchAll.js
+++ b/fetchAll.js
@@ -1,6 +1,7 @@
 const fetchYearSem = require("./crawler/fetchYearSem");
 const { fetchCourse } = require("./crawler/fetchCourse");
 const { fetchDepartment } = require("./crawler/fetchDepartment");
+const { fetchMProgram } = require("./crawler/fetchMProgram");
 
 (async () => {
   let { years } = await fetchYearSem();
@@ -8,6 +9,7 @@ const { fetchDepartment } = require("./crawler/fetchDepartment");
     for (let sem of years[year]) {
       await Promise.all([
         fetchDepartment(year, sem),
+        fetchMProgram(year, sem),
         fetchCourse("日間部", year, sem),
         fetchCourse("進修部", year, sem),
         fetchCourse("研究所(日間部、進修部、週末碩士班)", year, sem),

--- a/fetchMProgram.js
+++ b/fetchMProgram.js
@@ -1,0 +1,15 @@
+// node fetchMProgram.js <year> <sem>
+const fetchYearSem = require("./crawler/fetchYearSem");
+const { fetchMProgram } = require("./crawler/fetchMProgram");
+
+(async () => {
+  let year = process.argv[2] || null,
+    sem = process.argv[3] || null;
+  if (!year || !sem) {
+    let { current } = await fetchYearSem();
+    year = current.year;
+    sem = current.sem;
+  }
+  await fetchMProgram(year, sem);
+  console.log("All done!");
+})();


### PR DESCRIPTION
## English

This pull request adds Micro Program support to the NTUT Course Crawler so the frontend can query micro program data alongside existing course/department datasets.

### What’s included

- New crawler for Micro Programs: fetches micro program listings/metadata and normalizes the fields to align with the existing datasets’ patterns where reasonable.
 
- JSON export: outputs a dedicated JSON file under the same static data mechanism (GitHub Pages) used by other datasets, so the frontend can access it by prefixing the API endpoint (same rule as /main.json).

- Consistent schema: fields are organized to be analogous to class/department where applicable (e.g., id, name, code, department, url/source, etc.), keeping the shape simple to consume on the web client.

### How the frontend should access

- Follow the same API doc convention: prepend the Endpoint before the file path, just like accessing /main.json (see API doc note).

- The new micro program JSON will be available under the exported path once this PR is merged and data is published. 

### Why

- Enables the new Micro Program Query page on the frontend to function with a first-party dataset.

- Keeps the crawler/export flow consistent with the project’s current design (generate JSON to gh-pages branch for static access). 


### Verified

- Tested end-to-end in my deployment together with the updated frontend page. (See frontend PR context.)

## 中文

本 PR 為 北科課程爬蟲 新增 微學程 的資料蒐集與輸出，讓前端可與既有課程/系所資料一樣地被查詢。

### 內容重點

- 新增微學程爬蟲：擷取微學程清單/中繼資料，並在可行範圍內，將欄位結構比照既有資料集進行正規化。

- 輸出 JSON：以與現有資料一致的方式輸出到 GitHub Pages（靜態檔），前端可用與 /main.json 相同的規則，於路徑前加上 Endpoint 存取。

- 結構一致性：欄位包含 id、name、code、department、url/source 等（視實際可取得資料而定），盡量貼近班級/系所資料的使用體驗。

### 前端如何存取

- 依 API 文件慣例：在路徑前加上 Endpoint（與 /main.json 相同規則），即可取得新的微學程 JSON 檔案。

- 為什麼需要

- 供前端 「微學程查詢」 頁面使用，資料來自第一方爬取。

- 維持本專案現行的工作流程（以爬蟲產生 JSON，發布至 gh-pages 後供前端讀取）。

測試

- 已在個人部署與更新後的前端頁面進行核對測試（詳見前端 PR）。

## ✅ Changes in this PR

 Add crawler logic to fetch Micro Program data (rate-limited like existing crawlers)

 Normalize fields and map to a stable, frontend-friendly shape

 Export Micro Program dataset as JSON under the static data output (GitHub Pages)

 Document the new dataset path and usage note for the frontend

 Smoke-tested end-to-end with the updated frontend Micro Program page